### PR TITLE
add a scheduled build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
-
+  schedule:
+    - cron: "50 0 * * *"
 
 jobs:
   linux:


### PR DESCRIPTION
To continue monitoring the status of `main`, we should build every day.