### PR TITLE
always vendor in libusb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ git-version = "0.3.4"
 hidapi = "2.3.3"
 log = "~0.4"
 regex = "~1"
-rusb = "0.9.3"
+rusb = { version = "0.9.3", features = ["vendored"] }
 dfu-libusb = "0.5.1"
 
 [dev-dependencies]


### PR DESCRIPTION
In order to make sure we can distribute to any machine that doesn't have libusb installed, we should always vendor in the library.