### PR TITLE
gracefully handle an unfulfillable request on nScope v1

### DIFF
--- a/examples/data_request.py
+++ b/examples/data_request.py
@@ -7,8 +7,8 @@ nlab = LabBench.open_first_available()
 nlab.ax_turn_on(1)
 nlab.ax_set_amplitude(1, 3.5)
 nlab.ax_set_polarity(1, AnalogSignalPolarity.Bipolar)
-number_of_samples = 19200
-sample_rate = 8000.0
+number_of_samples = 3000
+sample_rate = 1000.0
 
 data = nlab.read_all_channels(sample_rate, number_of_samples)
 nlab.ax_turn_off(1)

--- a/examples/data_request.rs
+++ b/examples/data_request.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     nlab.a1.turn_on();
 
-    let sweep_handle = nlab.request(8000.0, 19200, None);
+    let sweep_handle = nlab.request(100000.0, 3000, None);
 
     for sample in sweep_handle.receiver {
         println!("{:?}", sample.data);
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     nlab.a1.turn_off();
     
     
-    let sweep_handle = nlab.request(8000.0, 19200, Some(Trigger{
+    let sweep_handle = nlab.request(100000.0, 3000, Some(Trigger{
         is_enabled: true,
         trigger_type: TriggerType::RisingEdge,
         source_channel: 0,

--- a/src/scope/data_requests.rs
+++ b/src/scope/data_requests.rs
@@ -110,8 +110,15 @@ impl ScopeCommand for DataRequest {
         };
 
         let total_samples = *self.remaining_samples.read().unwrap();
+
         if samples_between_records < 250 && total_samples * num_channels_on as u32 > 3200 {
-            return Err("Data not recordable".into());
+            let channel_string = match num_channels_on {
+                1 => format!("{num_channels_on} channel"),
+                _ => format!("{num_channels_on} channels")
+            };
+
+            return Err(format!("Cannot fulfill data request: maximum number of samples with {} at {} hz is {}", 
+                               channel_string, self.sample_rate_hz, 3200 / num_channels_on).into());
         }
 
 
@@ -165,7 +172,8 @@ impl ScopeCommand for DataRequest {
         let total_samples = *self.remaining_samples.read().unwrap();
         debug!("Requesting {} samples with {} samples between records", total_samples, samples_between_records);
         if samples_between_records < 25 && total_samples > 2400 {
-            return Err("Data not recordable".into());
+            return Err(format!("Cannot fulfill data request: maximum number of samples at {} hz is {}",
+                               self.sample_rate_hz, 2400).into());
         }
 
         usb_buf[2..6].copy_from_slice(&samples_between_records.to_le_bytes());


### PR DESCRIPTION
When requesting an amount of data that cannot be fulfilled (too many samples at too fast a sample rate), nScope v1 gives an unhelpful error message and hangs.  This PR fixes both of these issues, and also changes the examples to work with both v1 and v2 devices.