### PR TITLE
Update to use newer print syntax

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -111,7 +111,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter 3.8 3.9 3.10 3.11 3.12 3.13
+          args: --release --out dist --interpreter 3.9 3.10 3.11 3.12 3.13
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/examples/list_all_nlabs.rs
+++ b/examples/list_all_nlabs.rs
@@ -18,12 +18,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let bench = LabBench::new()?;
 
     // Print the bench to show a list of detected nLabs
-    println!("Lab Bench: \n{:?}", bench);
+    println!("Lab Bench: \n{bench:?}");
 
     println!("\nManual list of all detected nLabs:");
     // Or loop over all nLab links in the list and print them
     for nlab_link in bench.list() {
-        println!("    {:?}", nlab_link)
+        println!("    {nlab_link:?}")
     }
     Ok(())
 }

--- a/examples/monitor_power.rs
+++ b/examples/monitor_power.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     let state = format!("{:?}", status.state);
                     println!("{:>15}: {:.3} Watts", state, status.usage)
                 },
-                Err(error) => eprintln!("{}", error),
+                Err(error) => eprintln!("{error}"),
             }
         }
 

--- a/examples/update_firmware.rs
+++ b/examples/update_firmware.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut bench = LabBench::new()?;
 
     // Print the bench to show a list of detected nLabs
-    println!("{:?}", bench);
+    println!("{bench:?}");
 
     for nlab_link in bench.list() {
         // Request DFU on any nLab that is available
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     bench.refresh();
 
     // Print the bench to show the refreshed list
-    println!("{:?}", bench);
+    println!("{bench:?}");
 
     for nlab_link in bench.list() {
         if let Err(e) = nlab_link.update() {

--- a/src/lab_bench.rs
+++ b/src/lab_bench.rs
@@ -314,8 +314,7 @@ impl fmt::Debug for NlabLink {
         if self.in_dfu {
             write!(
                 f,
-                "Link to {} [ in DFU mode ]",
-                device_name,
+                "Link to {device_name} [ in DFU mode ]",
             )
         } else if self.needs_update {
             write!(

--- a/src/python/analog_output.rs
+++ b/src/python/analog_output.rs
@@ -12,7 +12,7 @@ impl python::Nlab {
         let ax = match ch {
             1 => &scope.a1,
             2 => &scope.a2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         Ok(ax.is_on())
@@ -24,7 +24,7 @@ impl python::Nlab {
         let ax = match ch {
             1 => &scope.a1,
             2 => &scope.a2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         Ok(ax.frequency())
@@ -36,7 +36,7 @@ impl python::Nlab {
         let ax = match ch {
             1 => &scope.a1,
             2 => &scope.a2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         Ok(ax.amplitude())
@@ -48,7 +48,7 @@ impl python::Nlab {
         let ax = match ch {
             1 => &scope.a1,
             2 => &scope.a2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         Ok(ax.wave_type())
@@ -60,7 +60,7 @@ impl python::Nlab {
         let ax = match ch {
             1 => &scope.a1,
             2 => &scope.a2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         Ok(ax.polarity())
@@ -72,7 +72,7 @@ impl python::Nlab {
         let ax = match ch {
             1 => &scope.a1,
             2 => &scope.a2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         ax.turn_on();
@@ -85,7 +85,7 @@ impl python::Nlab {
         let ax = match ch {
             1 => &scope.a1,
             2 => &scope.a2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         ax.turn_off();
@@ -98,7 +98,7 @@ impl python::Nlab {
         let ax = match ch {
             1 => &scope.a1,
             2 => &scope.a2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         ax.set_frequency(desired_hz);
@@ -111,7 +111,7 @@ impl python::Nlab {
         let ax = match ch {
             1 => &scope.a1,
             2 => &scope.a2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         ax.set_amplitude(desired_volts);
@@ -124,7 +124,7 @@ impl python::Nlab {
         let ax = match ch {
             1 => &scope.a1,
             2 => &scope.a2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         ax.set_wave_type(wave_type);
@@ -137,7 +137,7 @@ impl python::Nlab {
         let ax = match ch {
             1 => &scope.a1,
             2 => &scope.a2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         ax.set_polarity(polarity);

--- a/src/python/bench.rs
+++ b/src/python/bench.rs
@@ -21,7 +21,7 @@ impl python::LabBench {
     fn list_all_nlabs() {
         if let Ok(bench) = LabBench::new() {
             for nlab_link in bench.list() {
-                println!("{:?}", nlab_link);
+                println!("{nlab_link:?}");
             }
         } else {
             println!("Cannot create LabBench");

--- a/src/python/pulse_output.rs
+++ b/src/python/pulse_output.rs
@@ -12,7 +12,7 @@ impl python::Nlab {
         let px = match ch {
             1 => &scope.p1,
             2 => &scope.p2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         Ok(px.is_on())
@@ -24,7 +24,7 @@ impl python::Nlab {
         let px = match ch {
             1 => &scope.p1,
             2 => &scope.p2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         Ok(px.frequency())
@@ -36,7 +36,7 @@ impl python::Nlab {
         let px = match ch {
             1 => &scope.p1,
             2 => &scope.p2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         Ok(px.duty())
@@ -48,7 +48,7 @@ impl python::Nlab {
         let px = match ch {
             1 => &scope.p1,
             2 => &scope.p2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         Ok(px.period().as_secs_f64())
@@ -60,7 +60,7 @@ impl python::Nlab {
         let px = match ch {
             1 => &scope.p1,
             2 => &scope.p2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         Ok(px.pulse_width().as_secs_f64())
@@ -72,7 +72,7 @@ impl python::Nlab {
         let px = match ch {
             1 => &scope.p1,
             2 => &scope.p2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         px.turn_on();
@@ -85,7 +85,7 @@ impl python::Nlab {
         let px = match ch {
             1 => &scope.p1,
             2 => &scope.p2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         px.turn_off();
@@ -98,7 +98,7 @@ impl python::Nlab {
         let px = match ch {
             1 => &scope.p1,
             2 => &scope.p2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         px.set_frequency(desired_hz);
@@ -111,7 +111,7 @@ impl python::Nlab {
         let px = match ch {
             1 => &scope.p1,
             2 => &scope.p2,
-            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {}", ch)))
+            _ => return Err(PyValueError::new_err(format!("Invalid channel number: {ch}")))
         };
 
         px.set_duty(desired_percentage);

--- a/src/scope/commands.rs
+++ b/src/scope/commands.rs
@@ -49,7 +49,7 @@ pub(crate) enum Command {
 
 impl Command {
     pub(super) fn fill_tx_buffer_legacy(&mut self, usb_buf: &mut [u8; 65]) -> Result<(), Box<dyn Error>> {
-        debug!("Processed command: {:?}", self);
+        debug!("Processed command: {self:?}");
         match self {
             Command::Quit => { Ok(()) }
             Command::Initialize(power_on, _) => {

--- a/src/scope/data_requests.rs
+++ b/src/scope/data_requests.rs
@@ -124,7 +124,7 @@ impl ScopeCommand for DataRequest {
 
         usb_buf[3..=6].copy_from_slice(&samples_between_records.to_le_bytes());
         usb_buf[7..=10].copy_from_slice(&total_samples.to_le_bytes());
-        trace!("Requesting {} samples with {} samples between records", total_samples, samples_between_records);
+        trace!("Requesting {total_samples} samples with {samples_between_records} samples between records");
 
         if self.trigger.is_enabled {
             usb_buf[11] = self.trigger.source_channel as u8 | (self.trigger.trigger_type.value() << 2);
@@ -170,7 +170,7 @@ impl ScopeCommand for DataRequest {
         let samples_between_records: u32 = (2_000_000.0 / self.sample_rate_hz) as u32;
 
         let total_samples = *self.remaining_samples.read().unwrap();
-        debug!("Requesting {} samples with {} samples between records", total_samples, samples_between_records);
+        debug!("Requesting {total_samples} samples with {samples_between_records} samples between records");
         if samples_between_records < 25 && total_samples > 2400 {
             return Err(format!("Cannot fulfill data request: maximum number of samples at {} hz is {}",
                                self.sample_rate_hz, 2400).into());
@@ -213,7 +213,7 @@ impl ScopeCommand for DataRequest {
             usb_buf[16..=17].copy_from_slice(&trigger_level.to_le_bytes());
 
             let trigger_delay = 2 * self.trigger.trigger_delay_us / samples_between_records;
-            debug!("Trigger Delay: {:?}", trigger_delay);
+            debug!("Trigger Delay: {trigger_delay:?}");
             usb_buf[18..=21].copy_from_slice(&trigger_delay.to_le_bytes());
         } else {
             usb_buf[14..=21].fill(0);
@@ -229,7 +229,7 @@ impl ScopeCommand for DataRequest {
         {
             let mut remaining_samples = self.remaining_samples.write().unwrap();
             *remaining_samples -= number_received_samples;
-            trace!("Received {} samples, {} samples remaining", number_received_samples, remaining_samples);
+            trace!("Received {number_received_samples} samples, {remaining_samples} samples remaining");
         }
 
 
@@ -320,7 +320,7 @@ impl DataRequest {
             if complete_samples > 0 {
                 let mut remaining_samples = self.remaining_samples.write().unwrap();
                 *remaining_samples -= complete_samples as u32;
-                trace!("Received {} samples, {} samples remaining", complete_samples, remaining_samples);
+                trace!("Received {complete_samples} samples, {remaining_samples} samples remaining");
             }
         }
     }

--- a/src/scope/power.rs
+++ b/src/scope/power.rs
@@ -34,7 +34,7 @@ impl Default for PowerStatus {
 #[pymethods]
 impl PowerStatus {
     fn __repr__(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 

--- a/src/scope/run_loops/v1.rs
+++ b/src/scope/run_loops/v1.rs
@@ -71,12 +71,12 @@ impl crate::Nlab {
                         active_data_request = Some(request_id);
                     }
                     active_requests_map.insert(request_id, command);
-                    trace!("Sent request {}", request_id);
+                    trace!("Sent request {request_id}");
                 } else {
                     // If we cannot successfully create a request packet, then
                     // 1. Print the error
                     // 2. send a null request for status
-                    eprintln!("{:?}", result);
+                    eprintln!("{result:?}");
                     if hid_device.write(&commands::NULL_REQ).is_err() {
                         eprintln!("USB write error, ending nLab connection");
                         break 'communication;
@@ -128,9 +128,9 @@ impl crate::Nlab {
                             }
                         }
 
-                        trace!("Finished request ID: {}, ADRQ: {:?}", response.request_id, active_data_request);
+                        trace!("Finished request ID: {}, ADRQ: {active_data_request:?}", response.request_id);
                     } else {
-                        trace!("Received request ID: {}, ADRQ: {:?}", response.request_id, active_data_request);
+                        trace!("Received request ID: {}, ADRQ: {active_data_request:?}", response.request_id);
                     }
                 } else {
                     error!("Received response for request {}, but cannot find a record of that request", response.request_id);

--- a/src/scope/run_loops/v2.rs
+++ b/src/scope/run_loops/v2.rs
@@ -29,7 +29,7 @@ impl crate::Nlab {
                 if let Ok(()) = rq.stop_recv.try_recv() {
                     // We have received a stop signal
                     command_tx.send(Command::StopData).unwrap();
-                    debug!("Sent a stop command to request {}", id);
+                    debug!("Sent a stop command to request {id}");
                 }
             }
 
@@ -79,7 +79,7 @@ impl crate::Nlab {
                                                               &outgoing_usb_buffer,
                                                               Duration::from_millis(100))
                     {
-                        error!("USB write error: {:?}", error);
+                        error!("USB write error: {error:?}");
                         break 'communication;
                     }
                 }
@@ -108,16 +108,16 @@ impl crate::Nlab {
 
                             // If the command has finished it's work
                             if command.is_finished() {
-                                debug!("Finished request ID: {}", request_id);
+                                debug!("Finished request ID: {request_id}");
                                 if let Command::StopData = command {
                                     active_data_request = None;
                                 }
                             } else {
-                                debug!("Received request ID: {}", request_id);
+                                debug!("Received request ID: {request_id}");
                             }
 
                             if let Command::RequestData(_) = command {
-                                debug!("Setting Active Data Request: {}", request_id);
+                                debug!("Setting Active Data Request: {request_id}");
                                 active_data_request = active_comms_request.take();
                             } else {
                                 active_comms_request = None;
@@ -128,7 +128,7 @@ impl crate::Nlab {
                     }
                 }
                 Err(error) => {
-                    error!("USB read error: {:?}", error);
+                    error!("USB read error: {error:?}");
                     break 'communication;
                 }
             }
@@ -144,14 +144,14 @@ impl crate::Nlab {
                             Err(rusb::Error::Timeout) => {}
                             Ok(_) => {
                                 let received_request_id = buf[0];
-                                debug!("Received data for request {}, active request {}", received_request_id, request_id);
+                                debug!("Received data for request {received_request_id}, active request {request_id}");
                                 if received_request_id == *request_id {
                                     data_request.handle_incoming_data(buf, ch);
                                     received_ch_data = true;
                                 }
                             }
                             Err(error) => {
-                                error!("USB read error: {:?}", error);
+                                error!("USB read error: {error:?}");
                                 break 'communication;
                             }
                         }
@@ -165,7 +165,7 @@ impl crate::Nlab {
                 if let Some((request_id, Command::RequestData(data_request))) = &active_data_request {
                     data_request.collate_results();
                     if data_request.is_finished() {
-                        debug!("Finished request ID: {}", request_id);
+                        debug!("Finished request ID: {request_id}");
                         active_data_request = None;
                     }
                 }


### PR DESCRIPTION
Per RFC2795 we should be using implicit named arguments when formatting text.