### PR TITLE
Handle situations in which the nLab device has newer firmware than the nlabapi

### DIFF
--- a/src/firmware.rs
+++ b/src/firmware.rs
@@ -9,4 +9,4 @@
  **************************************************************************************************/
 
 pub(crate) static FIRMWARE: &[u8] = include_bytes!("firmware/v2");
-pub(crate) static FIRMWARE_VERSION: u16 = 0x0206;
+pub(crate) static SUPPORTED_FIRMWARE_VERSION: u16 = 0x0206;

--- a/src/python.rs
+++ b/src/python.rs
@@ -21,7 +21,7 @@ fn run_cli(_py: Python) -> PyResult<()> {
     let cli = Cli::parse_from(args);
 
     match &cli.command {
-        Commands::Update => { LabBench::update_all_nlabs() }
+        Commands::Update(args) => { LabBench::update_all_nlabs(args.force_downgrade) }
     }
 }
 

--- a/src/python/bench.rs
+++ b/src/python/bench.rs
@@ -11,7 +11,18 @@ impl python::LabBench {
         if let Ok(bench) = LabBench::new() {
             return match bench.open_first_available(true) {
                 Ok(scope) => Ok(python::Nlab(scope)),
-                Err(err) => Err(PyRuntimeError::new_err(err)),
+                Err(err) => {
+                    if err.to_string().contains("downgrade") {
+                        let error_lines = [
+                            "Device detected with newer firmware than the installed nlabapi.",
+                            "To ensure compatibility, please update nlabapi by running:",
+                            "    pip install --upgrade nlabapi",
+                        ];
+                        Err(PyRuntimeError::new_err(error_lines.join("\n")))
+                    } else {
+                        Err(PyRuntimeError::new_err(err))
+                    }
+                },
             };
         }
         Err(PyRuntimeError::new_err("Cannot create LabBench"))
@@ -37,29 +48,72 @@ impl python::LabBench {
     }
 
     #[staticmethod]
-    pub(super) fn update_all_nlabs() -> PyResult<()> {
+    #[pyo3(signature = (force_downgrade=false))]
+    pub(super) fn update_all_nlabs(force_downgrade:bool) -> PyResult<()> {
         if let Ok(mut bench) = LabBench::new() {
+            if bench.list().count() == 0 {
+                return Err(PyRuntimeError::new_err("No nLab devices found."));
+            }
+
             for nlab_link in bench.list() {
-                // Request DFU on any nLab that is available
-                if nlab_link.available {
-                    if let Err(e) = nlab_link.request_dfu() {
-                        println!("Failed to request DFU on an available nLab: {e}");
-                        return Err(PyRuntimeError::new_err(format!("{e}")));
+                if nlab_link.must_be_downgraded() {
+                    let error_lines = [
+                        "Device detected with newer firmware than the installed nlabapi.",
+                        "To ensure compatibility, please update nlabapi by running:",
+                        "    pip install --upgrade nlabapi",
+                    ];
+                    if force_downgrade {
+                        println!("{}", error_lines.join("\n"));
+                        println!("Forcing downgrade by request")
+                    } else {
+                        return Err(PyRuntimeError::new_err(error_lines.join("\n")));
                     }
                 }
             }
-            println!("Updating all connected nLabs...");
+
+            let mut device_update_count = 0;
+            for nlab_link in bench.list() {
+                if nlab_link.needs_update {
+                    if let Err(e) = nlab_link.request_dfu() {
+                        println!("Failed to request DFU on an available nLab: {e}");
+                        return Err(PyRuntimeError::new_err(format!("{e}")));
+                    } else {
+                        device_update_count += 1;
+                    }
+                }
+            }
+
+            if device_update_count == 0 {
+                println!("No firmware updates are needed for connected nLab devices.");
+                return Ok(());
+            }
+            match device_update_count {
+                1 => { println!("Updating connected nLab...") }
+                _ => { println!("Updating {device_update_count} connected nLabs...") }
+            }
+
             // Wait 500ms for the scope to detach and re-attach as DFU
             thread::sleep(Duration::from_millis(500));
             bench.refresh();
 
             for nlab_link in bench.list() {
-                if let Err(e) = nlab_link.update() {
-                    println!("Encountered an error updating nLab: {e}");
-                    return Err(PyRuntimeError::new_err(format!("{e}")));
+                if nlab_link.in_dfu {
+                    if let Err(e) = nlab_link.update() {
+                        println!("Encountered an error updating nLab: {e}");
+                        return Err(PyRuntimeError::new_err(format!("{e}")));
+                    } else {
+                        device_update_count -= 1;
+                    }
                 }
             }
-            println!("Update complete!");
+            if device_update_count == 0 {
+                println!("Update complete!");
+            } else {
+                match device_update_count {
+                    1 => { println!("Failed to update {device_update_count} nLab") }
+                    _ => { println!("Failed to update {device_update_count} nLabs") }
+                }
+            }
         }
         Ok(())
     }

--- a/src/python/cli.rs
+++ b/src/python/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, Args};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -11,5 +11,11 @@ pub(super) struct Cli {
 #[derive(Subcommand, Debug)]
 pub(super) enum Commands {
     /// Update all detected nLabs
-    Update,
+    Update(UpdateArgs),
+}
+
+#[derive(Args, Debug)]
+pub(super) struct UpdateArgs {
+    #[arg(long = "force-downgrade", help = "Force nLab to downgrade firmware to match nlabapi")]
+    pub force_downgrade: bool,
 }


### PR DESCRIPTION
This PR surfaces whether or not the device has newer or older firmware than the nlabapi. In the case that the device is newer, we should encourage users to upgrade the nlabapi. We still allow for forcing a downgrade in case a user really doesn't wish to upgrade.