### PR TITLE
Build python packages using stable ABI, include python 3.14

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -138,9 +138,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64
-          - runner: macos-14
+          - runner: macos-latest
             target: aarch64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -45,7 +45,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter 3.10
+          args: --release --out dist --interpreter 3.10 3.11 3.12 3.13 3.14
           sccache: 'true'
           manylinux: auto
           before-script-linux: |
@@ -105,11 +105,27 @@ jobs:
         with:
           python-version: '3.10'
           architecture: ${{ matrix.platform.target }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          architecture: ${{ matrix.platform.target }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          architecture: ${{ matrix.platform.target }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          architecture: ${{ matrix.platform.target }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+          architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter 3.10
+          args: --release --out dist --interpreter 3.10 3.11 3.12 3.13 3.14
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -135,7 +151,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter 3.10
+          args: --release --out dist --interpreter 3.10 3.11 3.12 3.13 3.14
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -45,7 +45,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
+          args: --release --out dist --interpreter 3.10
           sccache: 'true'
           manylinux: auto
           before-script-linux: |
@@ -105,23 +105,11 @@ jobs:
         with:
           python-version: '3.10'
           architecture: ${{ matrix.platform.target }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          architecture: ${{ matrix.platform.target }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          architecture: ${{ matrix.platform.target }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-          architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
+          args: --release --out dist --interpreter 3.10
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -147,7 +135,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter 3.10 3.11 3.12 3.13
+          args: --release --out dist --interpreter 3.10
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ regex = "~1"
 rusb = { version = "0.9.3", features = ["vendored"] }
 dfu-libusb = "0.5.1"
 clap = { version = "4.5.16", features = ["derive"] }
-pyo3 = { version = "~0.25", features = ["multiple-pymethods"], optional = true }
+pyo3 = { version = "~0.25", features = ["multiple-pymethods", "abi3"], optional = true }
 
 [dev-dependencies]
 env_logger = "0.10.0"


### PR DESCRIPTION
Build with python 3.14, using a stable ABI. Addresses challenges raised in #30 